### PR TITLE
DR-1081: Export GOOGLE_CLOUD_DATA_PROJECT env var for connected tests.

### DIFF
--- a/src/gradleinttest.sh
+++ b/src/gradleinttest.sh
@@ -29,6 +29,7 @@ gradleinttest () {
   # determine id of integration project
   namespace_number=$(echo ${NAMESPACEINUSE} | sed 's/integration-//g')
   google_data_project="broad-jade-int-${namespace_number}-data"
+  echo "Running ${test_to_run} test with data project: ${google_data_project}"
 
   if [[ -n "${google_project}" ]] && [ -f jade-dev-account.json ] && [ -f jade-dev-account.pem ] && [[ "${test_to_run}" != "" ]]; then
     export PGHOST=$(ip route show default | awk '/default/ {print $3}')

--- a/src/gradleinttest.sh
+++ b/src/gradleinttest.sh
@@ -32,6 +32,9 @@ gradleinttest () {
   if [[ "${test_to_run}" == "testConnected" ]]; then
     google_data_project="broad-jade-integration-data"
     echo "Running ${test_to_run} test with data project: ${google_data_project}"
+  else
+    google_data_project=""
+    echo "Running ${test_to_run} test with data project env var unset: ${google_data_project}"
   fi
 
   if [[ -n "${google_project}" ]] && [ -f jade-dev-account.json ] && [ -f jade-dev-account.pem ] && [[ "${test_to_run}" != "" ]]; then

--- a/src/gradleinttest.sh
+++ b/src/gradleinttest.sh
@@ -21,12 +21,15 @@ cleaniampolicy () {
 }
 
 gradleinttest () {
-  if [ -f env_vars ] && [[ -n "${IT_JADE_API_URL}" ]] && [[ "${test_to_run}" == "testIntegration" ]]; then
-    echo "Getting GCR tags and IT_JADE_API_URL for integration test"
+  if [ -f env_vars ] && [[ -n "${IT_JADE_API_URL}" ]]; then
+    echo "Getting GCR tags and IT_JADE_API_URL for connected or integration test"
     eval $(cat env_vars)
-  else
-    echo "Skipping importing environment vars for gradleinttest"
   fi
+
+  # determine id of integration project
+  namespace_number=$(echo ${NAMESPACEINUSE} | sed 's/integration-//g')
+  google_data_project="broad-jade-int-${namespace_number}-data"
+
   if [[ -n "${google_project}" ]] && [ -f jade-dev-account.json ] && [ -f jade-dev-account.pem ] && [[ "${test_to_run}" != "" ]]; then
     export PGHOST=$(ip route show default | awk '/default/ {print $3}')
     export DB_DATAREPO_URI="jdbc:postgresql://${PGHOST}:5432/datarepo"
@@ -35,6 +38,7 @@ gradleinttest () {
     export IT_JADE_PEM_FILE_NAME=jade-dev-account.pem
     export GOOGLE_SA_CERT=jade-dev-account.pem
     export GOOGLE_CLOUD_PROJECT=${google_project}
+    export GOOGLE_CLOUD_DATA_PROJECT=${google_data_project}
     if [[ "${test_to_run}" == "testIntegration" ]]; then
       echo "Running integration tests against ${IT_JADE_API_URL}"
       cleaniampolicy

--- a/src/gradleinttest.sh
+++ b/src/gradleinttest.sh
@@ -21,15 +21,18 @@ cleaniampolicy () {
 }
 
 gradleinttest () {
-  if [ -f env_vars ] && [[ -n "${IT_JADE_API_URL}" ]]; then
-    echo "Getting GCR tags and IT_JADE_API_URL for connected or integration test"
+  if [ -f env_vars ] && [[ -n "${IT_JADE_API_URL}" ]] && [[ "${test_to_run}" == "testIntegration" ]]; then
+    echo "Getting GCR tags and IT_JADE_API_URL for integration test"
     eval $(cat env_vars)
+  else
+    echo "Skipping importing environment vars for gradleinttest"
   fi
 
-  # determine id of integration project
-  namespace_number=$(echo ${NAMESPACEINUSE} | sed 's/integration-//g')
-  google_data_project="broad-jade-int-${namespace_number}-data"
-  echo "Running ${test_to_run} test with data project: ${google_data_project}"
+  # hardcode data project for connected tests
+  if [[ "${test_to_run}" == "testConnected" ]]; then
+    google_data_project="broad-jade-integration-data"
+    echo "Running ${test_to_run} test with data project: ${google_data_project}"
+  fi
 
   if [[ -n "${google_project}" ]] && [ -f jade-dev-account.json ] && [ -f jade-dev-account.pem ] && [[ "${test_to_run}" != "" ]]; then
     export PGHOST=$(ip route show default | awk '/default/ {print $3}')


### PR DESCRIPTION
Set the GOOGLE_CLOUD_DATA_PROJET environment variable to the integration data project, for running the connected tests. Hard-coded to broad-jade-integration-data.