### PR TITLE
DR-1318, DR-1358, DR-1144 Update Test Runner smoke suite to collectMeasurements and uploadResults.

### DIFF
--- a/src/gradletestrunnersmoketest.sh
+++ b/src/gradletestrunnersmoketest.sh
@@ -12,7 +12,7 @@ gradletestrunnersmoketest () {
   ./gradlew spotbugsMain
 
   echo "Setting Test Runner environment variables"
-  export ORG_GRADLE_PROJECT_datarepoclientjar=$(ls ../datarepo-client/build/libs/*jar)
+  export ORG_GRADLE_PROJECT_datarepoclientjar=$(find .. -type f -name "datarepo-client*.jar")
   export TEST_RUNNER_SERVER_SPECIFICATION_FILE="${NAMESPACEINUSE}.json"
   export TEST_RUNNER_SA_KEY_DIRECTORY_PATH="${GITHUB_WORKSPACE}"
   echo "ORG_GRADLE_PROJECT_datarepoclientjar = ${ORG_GRADLE_PROJECT_datarepoclientjar}"

--- a/src/gradletestrunnersmoketest.sh
+++ b/src/gradletestrunnersmoketest.sh
@@ -14,10 +14,10 @@ gradletestrunnersmoketest () {
   echo "Setting Test Runner environment variables"
   export ORG_GRADLE_PROJECT_datarepoclientjar=$(ls ../datarepo-client/build/libs/*jar)
   export TEST_RUNNER_SERVER_SPECIFICATION_FILE="${NAMESPACEINUSE}.json"
-  export TEST_RUNNER_KEY_DIRECTORY_PATH="${GITHUB_WORKSPACE}"
+  export TEST_RUNNER_SA_KEY_DIRECTORY_PATH="${GITHUB_WORKSPACE}"
   echo "ORG_GRADLE_PROJECT_datarepoclientjar = ${ORG_GRADLE_PROJECT_datarepoclientjar}"
   echo "TEST_RUNNER_SERVER_SPECIFICATION_FILE = ${TEST_RUNNER_SERVER_SPECIFICATION_FILE}"
-  echo "TEST_RUNNER_KEY_DIRECTORY_PATH = ${TEST_RUNNER_KEY_DIRECTORY_PATH}"
+  echo "TEST_RUNNER_SA_KEY_DIRECTORY_PATH = ${TEST_RUNNER_SA_KEY_DIRECTORY_PATH}"
 
   echo "Running test suite"
   ./gradlew runTest --args="suites/PRSmokeTests.json tmp/TestRunnerResults"

--- a/src/gradletestrunnersmoketest.sh
+++ b/src/gradletestrunnersmoketest.sh
@@ -2,14 +2,30 @@
 
 gradletestrunnersmoketest () {
   export TEST_RUNNER_SERVER_SPECIFICATION_FILE="${NAMESPACEINUSE}.json"
-  export TEST_RUNNER_DELEGATOR_SA_FILE="github-action-k8-sa.json"
-  export TEST_RUNNER_SA_FILE="github-action-k8-sa.json"
+  export TEST_RUNNER_KEY_DIRECTORY_PATH="/github/workspace"
+  echo "GITHUB_WORKSPACE = ${GITHUB_WORKSPACE}"
+  echo "TEST_RUNNER_SERVER_SPECIFICATION_FILE = ${TEST_RUNNER_SERVER_SPECIFICATION_FILE}"
+  echo "TEST_RUNNER_KEY_DIRECTORY_PATH = ${TEST_RUNNER_KEY_DIRECTORY_PATH}"
   cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-client
+
   echo "Building Data Repo client library"
   ../gradlew clean assemble  
   cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-clienttests
   export ORG_GRADLE_PROJECT_datarepoclientjar=$(ls ../datarepo-client/build/libs/*jar)
+  echo "ORG_GRADLE_PROJECT_datarepoclientjar = ${ORG_GRADLE_PROJECT_datarepoclientjar}"
+
+  echo "Running spotless and spotbugs"
+  ./gradlew spotlessCheck
+  ./gradlew spotbugsMain
+
   echo "Running TestRunner suite"
   ./gradlew runTest --args="suites/PRSmokeTests.json tmp/TestRunnerResults"
+
+  echo "Collecting measurements"
+  ./gradlew collectMeasurements --args="AllMeasurements.json tmp/TestRunnerResults"
+
+  echo "Uploading results"
+  ./gradlew uploadResults --args="BroadJadeDev.json tmp/TestRunnerResults"
+
   cd ${GITHUB_WORKSPACE}/${workingDir}
 }

--- a/src/gradletestrunnersmoketest.sh
+++ b/src/gradletestrunnersmoketest.sh
@@ -6,16 +6,16 @@ gradletestrunnersmoketest () {
   echo "Building Data Repo client library"
   ../gradlew clean assemble  
   cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-clienttests
-  export ORG_GRADLE_PROJECT_datarepoclientjar=$(ls ../datarepo-client/build/libs/*jar)
-  echo "ORG_GRADLE_PROJECT_datarepoclientjar = ${ORG_GRADLE_PROJECT_datarepoclientjar}"
 
   echo "Running spotless and spotbugs"
   ./gradlew spotlessCheck
   ./gradlew spotbugsMain
 
   echo "Setting Test Runner environment variables"
+  export ORG_GRADLE_PROJECT_datarepoclientjar=$(ls ../datarepo-client/build/libs/*jar)
   export TEST_RUNNER_SERVER_SPECIFICATION_FILE="${NAMESPACEINUSE}.json"
   export TEST_RUNNER_KEY_DIRECTORY_PATH="${GITHUB_WORKSPACE}"
+  echo "ORG_GRADLE_PROJECT_datarepoclientjar = ${ORG_GRADLE_PROJECT_datarepoclientjar}"
   echo "TEST_RUNNER_SERVER_SPECIFICATION_FILE = ${TEST_RUNNER_SERVER_SPECIFICATION_FILE}"
   echo "TEST_RUNNER_KEY_DIRECTORY_PATH = ${TEST_RUNNER_KEY_DIRECTORY_PATH}"
 
@@ -23,7 +23,7 @@ gradletestrunnersmoketest () {
   ./gradlew runTest --args="suites/PRSmokeTests.json tmp/TestRunnerResults"
 
   echo "Collecting measurements"
-  ./gradlew collectMeasurements --args="AllMeasurements.json tmp/TestRunnerResults"
+  ./gradlew collectMeasurements --args="PRSmokeTests.json tmp/TestRunnerResults"
 
   echo "Uploading results"
   ./gradlew uploadResults --args="BroadJadeDev.json tmp/TestRunnerResults"

--- a/src/gradletestrunnersmoketest.sh
+++ b/src/gradletestrunnersmoketest.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 
 gradletestrunnersmoketest () {
-  export TEST_RUNNER_SERVER_SPECIFICATION_FILE="${NAMESPACEINUSE}.json"
-  export TEST_RUNNER_DELEGATOR_SA_FILE="github-action-k8-sa.json"
-  export TEST_RUNNER_SA_FILE="github-action-k8-sa.json"
-
   echo "Building Data Repo client library"
   cd ${GITHUB_WORKSPACE}/${workingDir}
   ENABLE_SUBPROJECT_TASKS=1 ./gradlew :datarepo-client:clean :datarepo-client:assemble

--- a/src/gradletestrunnersmoketest.sh
+++ b/src/gradletestrunnersmoketest.sh
@@ -1,11 +1,6 @@
 #!/bin/bash
 
 gradletestrunnersmoketest () {
-  export TEST_RUNNER_SERVER_SPECIFICATION_FILE="${NAMESPACEINUSE}.json"
-  export TEST_RUNNER_KEY_DIRECTORY_PATH="/github/workspace"
-  echo "GITHUB_WORKSPACE = ${GITHUB_WORKSPACE}"
-  echo "TEST_RUNNER_SERVER_SPECIFICATION_FILE = ${TEST_RUNNER_SERVER_SPECIFICATION_FILE}"
-  echo "TEST_RUNNER_KEY_DIRECTORY_PATH = ${TEST_RUNNER_KEY_DIRECTORY_PATH}"
   cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-client
 
   echo "Building Data Repo client library"
@@ -18,7 +13,13 @@ gradletestrunnersmoketest () {
   ./gradlew spotlessCheck
   ./gradlew spotbugsMain
 
-  echo "Running TestRunner suite"
+  echo "Setting Test Runner environment variables"
+  export TEST_RUNNER_SERVER_SPECIFICATION_FILE="${NAMESPACEINUSE}.json"
+  export TEST_RUNNER_KEY_DIRECTORY_PATH="${GITHUB_WORKSPACE}"
+  echo "TEST_RUNNER_SERVER_SPECIFICATION_FILE = ${TEST_RUNNER_SERVER_SPECIFICATION_FILE}"
+  echo "TEST_RUNNER_KEY_DIRECTORY_PATH = ${TEST_RUNNER_KEY_DIRECTORY_PATH}"
+
+  echo "Running test suite"
   ./gradlew runTest --args="suites/PRSmokeTests.json tmp/TestRunnerResults"
 
   echo "Collecting measurements"


### PR DESCRIPTION
- Update commands following environment variable changes in the Test Runner code (jade-data-repo GH repository PR for [DR-1318](https://broadworkbench.atlassian.net/browse/DR-1318)).

- Added collectMeasurements and uploadResults commands. ([DR-1358](https://broadworkbench.atlassian.net/browse/DR-1358))
- Added spotless and spotbugs checks. ([DR-1144](https://broadworkbench.atlassian.net/browse/DR-1144))