### PR TITLE
DR-1367 Build client from top level directory

### DIFF
--- a/src/gradletestrunnersmoketest.sh
+++ b/src/gradletestrunnersmoketest.sh
@@ -6,7 +6,7 @@ gradletestrunnersmoketest () {
   export TEST_RUNNER_SA_FILE="github-action-k8-sa.json"
   echo "Building Data Repo client library"
   cd ${GITHUB_WORKSPACE}/${workingDir}
-  ENABLE_SUBPROJECT_TASKS=1 ./gradlew clean assemble
+  ENABLE_SUBPROJECT_TASKS=1 ./gradlew :datarepo-client:clean :datarepo-client:assemble
   cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-clienttests
   export ORG_GRADLE_PROJECT_datarepoclientjar=$(find .. -type f -name "datarepo-client*.jar")
   echo "Running TestRunner suite"

--- a/src/gradletestrunnersmoketest.sh
+++ b/src/gradletestrunnersmoketest.sh
@@ -6,7 +6,7 @@ gradletestrunnersmoketest () {
   export TEST_RUNNER_SA_FILE="github-action-k8-sa.json"
   echo "Building Data Repo client library"
   cd ${GITHUB_WORKSPACE}/${workingDir}
-  ./gradlew clean assemble
+  ENABLE_SUBPROJECT_TASKS=1 ./gradlew clean assemble
   cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-clienttests
   export ORG_GRADLE_PROJECT_datarepoclientjar=$(find .. -type f -name "datarepo-client*.jar")
   echo "Running TestRunner suite"

--- a/src/gradletestrunnersmoketest.sh
+++ b/src/gradletestrunnersmoketest.sh
@@ -4,9 +4,9 @@ gradletestrunnersmoketest () {
   export TEST_RUNNER_SERVER_SPECIFICATION_FILE="${NAMESPACEINUSE}.json"
   export TEST_RUNNER_DELEGATOR_SA_FILE="github-action-k8-sa.json"
   export TEST_RUNNER_SA_FILE="github-action-k8-sa.json"
-  cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-client
   echo "Building Data Repo client library"
-  ../gradlew clean assemble  
+  cd ${GITHUB_WORKSPACE}/${workingDir}
+  ./gradlew clean assemble
   cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-clienttests
   export ORG_GRADLE_PROJECT_datarepoclientjar=$(find .. -type f -name "datarepo-client*.jar")
   echo "Running TestRunner suite"


### PR DESCRIPTION
Note: Related [PR](https://github.com/DataBiosphere/jade-data-repo/pull/633) in jade-data-repo repository.

When we changed to building the client library from the top-level directory instead of from the datarepo-client sub-directory, some API methods changed. This caused compile errors in the Test Runner tests that called these methods. This did not cause failures in the GH actions that ran Test Runner suites because they built the client locally instead of pulling from Maven (this is necessary because the code under test is not always merged yet).

These 2 PRs change the Test Runner to work with the updated client library, as built from the top-level directory. They also update the on-PR and perf-nightly GH actions to build the client locally from the top-level directory, so that the generated JAR file will always match what is pushed to Maven on merge.