### PR TITLE
Export client jar before running spotbugsMain

### DIFF
--- a/src/gradletestrunnersmoketest.sh
+++ b/src/gradletestrunnersmoketest.sh
@@ -6,10 +6,6 @@ gradletestrunnersmoketest () {
   ENABLE_SUBPROJECT_TASKS=1 ./gradlew :datarepo-client:clean :datarepo-client:assemble
   cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-clienttests
 
-  echo "Running spotless and spotbugs"
-  ./gradlew spotlessCheck
-  ./gradlew spotbugsMain
-
   echo "Setting Test Runner environment variables"
   export ORG_GRADLE_PROJECT_datarepoclientjar=$(find .. -type f -name "datarepo-client*.jar")
   export TEST_RUNNER_SERVER_SPECIFICATION_FILE="${NAMESPACEINUSE}.json"
@@ -17,6 +13,10 @@ gradletestrunnersmoketest () {
   echo "ORG_GRADLE_PROJECT_datarepoclientjar = ${ORG_GRADLE_PROJECT_datarepoclientjar}"
   echo "TEST_RUNNER_SERVER_SPECIFICATION_FILE = ${TEST_RUNNER_SERVER_SPECIFICATION_FILE}"
   echo "TEST_RUNNER_SA_KEY_DIRECTORY_PATH = ${TEST_RUNNER_SA_KEY_DIRECTORY_PATH}"
+  
+  echo "Running spotless and spotbugs"
+  ./gradlew spotlessCheck
+  ./gradlew spotbugsMain
 
   echo "Running test suite"
   ./gradlew runTest --args="suites/PRSmokeTests.json tmp/TestRunnerResults"


### PR DESCRIPTION
This fixes an issue where the test runner smoke tests were failing b/c they were using an out of date client jar to run spotbugsMain.

More detailed explanation from @fboulnois:
We had an order of operations issue. Before, we would run the` ./gradlew spotlessCheck` and `./gradlew spotbugsMain` before exporting the env var to the local jar. As a result, spotbugsMain would try to use the remote (and potentially out-of-date) jar file. Now, we have flipped that logic, so that the env vars are all exported first, and spotbugsMain ends up using the local jar (with the updated code) instead.