### PR TITLE
PF-181: Always try to uploadResults even if runTest or collectMeasurements fails.

### DIFF
--- a/src/gradletestrunnersmoketest.sh
+++ b/src/gradletestrunnersmoketest.sh
@@ -20,25 +20,19 @@ gradletestrunnersmoketest () {
 
   outputDir="tmp/TestRunnerResults"
 
+  # if runTest fails, then try to uploadResults before exiting with an error
   echo "Running test suite"
-  runTestOutput=$(./gradlew runTest --args="suites/PRSmokeTests.json $outputDir" 2>&1)
-  runTestExitCode=$?
-  echo "$runTestOutput"
-  if [ $runTestExitCode -eq 1 ]; then
-    echo "Running test suite failed, Uploading results"
-    ./gradlew uploadResults --args="BroadJadeDev.json $outputDir"
-    exit $runTestExitCode
-  fi
+  ./gradlew runTest --args="suites/PRSmokeTests.json $outputDir" ||
+  echo "Running test suite failed, Uploading results" &&
+  ./gradlew uploadResults --args="BroadJadeDev.json $outputDir" &&
+  exit 1
 
+  # if collectMeasurements fails, then try to uploadResults before exiting with an error
   echo "Collecting measurements"
-  collectMeasurementsOutput=$(./gradlew collectMeasurements --args="PRSmokeTests.json $outputDir" 2>&1)
-  collectMeasurementsExitCode=$?
-  echo "$collectMeasurementsOutput"
-  if  [ $collectMeasurementsExitCode -eq 1 ]; then
-    echo "Collecting measurements failed, Uploading results"
-    ./gradlew uploadResults --args="BroadJadeDev.json $outputDir"
-    exit $collectMeasurementsExitCode
-  fi
+  ./gradlew collectMeasurements --args="PRSmokeTests.json $outputDir" ||
+  echo "Collecting measurements failed, Uploading results" &&
+  ./gradlew uploadResults --args="BroadJadeDev.json $outputDir" &&
+  exit 1
 
   echo "Uploading results"
   ./gradlew uploadResults --args="BroadJadeDev.json $outputDir"

--- a/src/gradletestrunnersmoketest.sh
+++ b/src/gradletestrunnersmoketest.sh
@@ -23,16 +23,16 @@ gradletestrunnersmoketest () {
   # if runTest fails, then try to uploadResults before exiting with an error
   echo "Running test suite"
   ./gradlew runTest --args="suites/PRSmokeTests.json $outputDir" ||
-  echo "Running test suite failed, Uploading results" &&
-  ./gradlew uploadResults --args="BroadJadeDev.json $outputDir" &&
-  exit 1
+    echo "Running test suite failed, Uploading results" &&
+    ./gradlew uploadResults --args="BroadJadeDev.json $outputDir" &&
+    exit 1
 
   # if collectMeasurements fails, then try to uploadResults before exiting with an error
   echo "Collecting measurements"
   ./gradlew collectMeasurements --args="PRSmokeTests.json $outputDir" ||
-  echo "Collecting measurements failed, Uploading results" &&
-  ./gradlew uploadResults --args="BroadJadeDev.json $outputDir" &&
-  exit 1
+    echo "Collecting measurements failed, Uploading results" &&
+    ./gradlew uploadResults --args="BroadJadeDev.json $outputDir" &&
+    exit 1
 
   echo "Uploading results"
   ./gradlew uploadResults --args="BroadJadeDev.json $outputDir"


### PR DESCRIPTION
Changed the script that executes the Test Runner smoke test suite for the on-PR GitHub action, so that it runs uploadResults regardless of whether runTest or collectMeasurements fail.

Mostly done by @fboulnois, just originally opened and tested by me. Thanks for all the help!