### PR TITLE
PF-181: (part 2) Revert previous PF-181 changes.

### DIFF
--- a/src/gradletestrunnersmoketest.sh
+++ b/src/gradletestrunnersmoketest.sh
@@ -19,13 +19,13 @@ gradletestrunnersmoketest () {
   ./gradlew spotbugsMain
 
   echo "Running test suite"
-  ./gradlew runTest --args="suites/PRSmokeTests.json $outputDir"
+  ./gradlew runTest --args="suites/PRSmokeTests.json tmp/TestRunnerResults"
 
   echo "Collecting measurements"
-  ./gradlew collectMeasurements --args="PRSmokeTests.json $outputDir"
+  ./gradlew collectMeasurements --args="PRSmokeTests.json tmp/TestRunnerResults"
 
   echo "Uploading results"
-  ./gradlew uploadResults --args="BroadJadeDev.json $outputDir"
+  ./gradlew uploadResults --args="BroadJadeDev.json tmp/TestRunnerResults"
 
   cd ${GITHUB_WORKSPACE}/${workingDir}
 }

--- a/src/gradletestrunnersmoketest.sh
+++ b/src/gradletestrunnersmoketest.sh
@@ -18,21 +18,11 @@ gradletestrunnersmoketest () {
   ./gradlew spotlessCheck
   ./gradlew spotbugsMain
 
-  outputDir="tmp/TestRunnerResults"
-
-  # if runTest fails, then try to uploadResults before exiting with an error
   echo "Running test suite"
-  ./gradlew runTest --args="suites/PRSmokeTests.json $outputDir" ||
-    echo "Running test suite failed, Uploading results" &&
-    ./gradlew uploadResults --args="BroadJadeDev.json $outputDir" &&
-    exit 1
+  ./gradlew runTest --args="suites/PRSmokeTests.json $outputDir"
 
-  # if collectMeasurements fails, then try to uploadResults before exiting with an error
   echo "Collecting measurements"
-  ./gradlew collectMeasurements --args="PRSmokeTests.json $outputDir" ||
-    echo "Collecting measurements failed, Uploading results" &&
-    ./gradlew uploadResults --args="BroadJadeDev.json $outputDir" &&
-    exit 1
+  ./gradlew collectMeasurements --args="PRSmokeTests.json $outputDir"
 
   echo "Uploading results"
   ./gradlew uploadResults --args="BroadJadeDev.json $outputDir"


### PR DESCRIPTION
Script is not working as expected. Saw an error in the jade-data-repo bump version branch that I didn't see when testing against my branch.

Reverting previous [change](https://github.com/broadinstitute/datarepo-actions/pull/37) so that @snf2ye can put her change in.