### PR TITLE
PF-181: (Take 2) Always try to uploadResults even if runTest or collectMeasurements fails.

### DIFF
--- a/src/gradletestrunnersmoketest.sh
+++ b/src/gradletestrunnersmoketest.sh
@@ -14,10 +14,9 @@ gradletestrunnersmoketest () {
   echo "TEST_RUNNER_SERVER_SPECIFICATION_FILE = ${TEST_RUNNER_SERVER_SPECIFICATION_FILE}"
   echo "TEST_RUNNER_SA_KEY_DIRECTORY_PATH = ${TEST_RUNNER_SA_KEY_DIRECTORY_PATH}"
   
-  echo "Skipping spotless and spotbugs for now..."
-  # echo "Running spotless and spotbugs"
-  # ./gradlew spotlessCheck
-  # ./gradlew spotbugsMain
+  echo "Running spotless and spotbugs"
+  ./gradlew spotlessCheck
+  ./gradlew spotbugsMain
 
   local outputDir="/tmp/TestRunnerResults"
   echo "Output directory set to: $outputDir"
@@ -29,11 +28,12 @@ gradletestrunnersmoketest () {
     return 1)
   echo "Running test suite SUCCEEDED"
 
-  # echo "Collecting measurements"
-  # ./gradlew collectMeasurements --args="PRSmokeTests.json $outputDir" ||
-  #   (echo "Collecting measurements FAILED" &&
-  #   ./gradlew uploadResults --args="BroadJadeDev.json $outputDir" &&
-  #   return 1
+  echo "Collecting measurements"
+  ./gradlew collectMeasurements --args="PRSmokeTests.json $outputDir" ||
+    (echo "Collecting measurements FAILED" &&
+    ./gradlew uploadResults --args="BroadJadeDev.json $outputDir" &&
+    return 1)
+  echo "Collecting measurements SUCCEEDED"
 
   echo "Uploading results"
   ./gradlew uploadResults --args="BroadJadeDev.json $outputDir"

--- a/src/gradletestrunnersmoketest.sh
+++ b/src/gradletestrunnersmoketest.sh
@@ -14,9 +14,10 @@ gradletestrunnersmoketest () {
   echo "TEST_RUNNER_SERVER_SPECIFICATION_FILE = ${TEST_RUNNER_SERVER_SPECIFICATION_FILE}"
   echo "TEST_RUNNER_SA_KEY_DIRECTORY_PATH = ${TEST_RUNNER_SA_KEY_DIRECTORY_PATH}"
   
-  echo "Running spotless and spotbugs"
-  ./gradlew spotlessCheck
-  ./gradlew spotbugsMain
+  echo "Skipping spotless and spotbugs for now..."
+  # echo "Running spotless and spotbugs"
+  # ./gradlew spotlessCheck
+  # ./gradlew spotbugsMain
 
   local outputDir="/tmp/TestRunnerResults"
   echo "Output directory set to: $outputDir"

--- a/src/gradletestrunnersmoketest.sh
+++ b/src/gradletestrunnersmoketest.sh
@@ -22,17 +22,17 @@ gradletestrunnersmoketest () {
   local outputDir="/tmp/TestRunnerResults"
   echo "Output directory set to: $outputDir"
   
-  echo "Running test suite"
+  echo "Running tests"
   ./gradlew runTest --args="suites/PRSmokeTests.json $outputDir" ||
-    echo "Running test suite FAILED" &&
+    (echo "Running tests FAILED" &&
     ./gradlew uploadResults --args="BroadJadeDev.json $outputDir" &&
-    return 1
+    return 1)
   echo "Running test suite SUCCEEDED"
 
   # echo "Collecting measurements"
-  # ./gradlew collectMeasurements --args="PRSmokeTests.json tmp/TestRunnerResults" ||
-  #   echo "Collecting measurements failed, uploading results" &&
-  #   ./gradlew uploadResults --args="BroadJadeDev.json tmp/TestRunnerResults" &&
+  # ./gradlew collectMeasurements --args="PRSmokeTests.json $outputDir" ||
+  #   (echo "Collecting measurements FAILED" &&
+  #   ./gradlew uploadResults --args="BroadJadeDev.json $outputDir" &&
   #   return 1
 
   echo "Uploading results"

--- a/src/gradletestrunnersmoketest.sh
+++ b/src/gradletestrunnersmoketest.sh
@@ -19,10 +19,16 @@ gradletestrunnersmoketest () {
   ./gradlew spotbugsMain
 
   echo "Running test suite"
-  ./gradlew runTest --args="suites/PRSmokeTests.json tmp/TestRunnerResults"
+  ./gradlew runTest --args="suites/PRSmokeTests.json tmp/TestRunnerResults" ||
+    echo "Running test suite failed, uploading results" &&
+    ./gradlew uploadResults --args="BroadJadeDev.json tmp/TestRunnerResults" &&
+    return 1
 
   echo "Collecting measurements"
-  ./gradlew collectMeasurements --args="PRSmokeTests.json tmp/TestRunnerResults"
+  ./gradlew collectMeasurements --args="PRSmokeTests.json tmp/TestRunnerResults" ||
+    echo "Collecting measurements failed, uploading results" &&
+    ./gradlew uploadResults --args="BroadJadeDev.json tmp/TestRunnerResults" &&
+    return 1
 
   echo "Uploading results"
   ./gradlew uploadResults --args="BroadJadeDev.json tmp/TestRunnerResults"

--- a/src/gradletestrunnersmoketest.sh
+++ b/src/gradletestrunnersmoketest.sh
@@ -18,20 +18,24 @@ gradletestrunnersmoketest () {
   ./gradlew spotlessCheck
   ./gradlew spotbugsMain
 
+  local outputDir="/tmp/TestRunnerResults"
+  echo "Output directory set to: $outputDir"
+  
   echo "Running test suite"
-  ./gradlew runTest --args="suites/PRSmokeTests.json tmp/TestRunnerResults" ||
-    echo "Running test suite failed, uploading results" &&
-    ./gradlew uploadResults --args="BroadJadeDev.json tmp/TestRunnerResults" &&
+  ./gradlew runTest --args="suites/PRSmokeTests.json $outputDir" ||
+    echo "Running test suite FAILED" &&
+    ./gradlew uploadResults --args="BroadJadeDev.json $outputDir" &&
     return 1
+  echo "Running test suite SUCCEEDED"
 
-  echo "Collecting measurements"
-  ./gradlew collectMeasurements --args="PRSmokeTests.json tmp/TestRunnerResults" ||
-    echo "Collecting measurements failed, uploading results" &&
-    ./gradlew uploadResults --args="BroadJadeDev.json tmp/TestRunnerResults" &&
-    return 1
+  # echo "Collecting measurements"
+  # ./gradlew collectMeasurements --args="PRSmokeTests.json tmp/TestRunnerResults" ||
+  #   echo "Collecting measurements failed, uploading results" &&
+  #   ./gradlew uploadResults --args="BroadJadeDev.json tmp/TestRunnerResults" &&
+  #   return 1
 
   echo "Uploading results"
-  ./gradlew uploadResults --args="BroadJadeDev.json tmp/TestRunnerResults"
+  ./gradlew uploadResults --args="BroadJadeDev.json $outputDir"
 
   cd ${GITHUB_WORKSPACE}/${workingDir}
 }


### PR DESCRIPTION
The on-PR GH action should:
- Always try to uploadResults for Test Runner tests, regardless of whether or where an error occurred.
- Fail if any of the tests or Gradle tasks (runTest, collectMeasurements, uploadResults) error out.

There were three things I changed from take 1 of this ticket:
- Use parentheses around the 3 commands to run in case of failure.
- Changed the outputDir variable to be locally scoped.
- Use return instead of exit.

I think the unexpected behavior after I merged take 1 was due to the way I was testing. If the TestRunner class threw an exception it was treated differently than if a test script class threw an exception. I've fixed that also in the main jade-data-repo PR.

To test this, I forced errors in several places and confirmed that the GH action check had the correct status (pass/fail) and that the results were uploaded to the broad-jade-testrunnerresults project (and gs://broad-jade-dev-testrunnerresults bucket in it) regardless.

Things I tested:
- Forced error in TestRunner class. [Failed](https://github.com/DataBiosphere/jade-data-repo/runs/1489420808), as expected. Confirmed results were uploaded to bucket gs://broad-jade-dev-testrunnerresults/bbab82df-2dd6-40ab-9422-48724351a21d.tar.gz
- Forced error in MeasurementCollector class. [Failed](https://github.com/DataBiosphere/jade-data-repo/runs/1489473970), as expected. Confirmed results were uploaded to bucket gs://broad-jade-dev-testrunnerresults/51e28907-a026-4325-839d-7344ca3634ed.tar.gz
- Forced error in a test script class. [Failed](https://github.com/DataBiosphere/jade-data-repo/runs/1489539866), as expected. Confirmed results were uploaded to bucket gs://broad-jade-dev-testrunnerresults/9df69334-82f3-44dc-aad2-24db8ae6fed0.tar.gz
- Removed all forced errors. [Succeeded](https://github.com/DataBiosphere/jade-data-repo/runs/1489610351), as expected. Confirmed results were uploaded to bucket gs://broad-jade-dev-testrunnerresults/b26c8b5a-4b78-42ce-bdbe-29a4134ee869.tar.gz

Parentheses examples:
```
marikomedlock-macbookpro:datarepo-clienttests marikomedlock$ true || (echo "after OR" && echo "after AND")
marikomedlock-macbookpro:datarepo-clienttests marikomedlock$ true || echo "after OR" && echo "after AND"
after AND
```