### PR TITLE
DR-1549: Silence gradlew in tests

### DIFF
--- a/src/gradleinttest.sh
+++ b/src/gradleinttest.sh
@@ -49,6 +49,7 @@ gradleinttest () {
     # required for tests
     ./gradlew assemble
     ./gradlew -w check --scan
+    echo "Running ${test_to_run}"
     ./gradlew -w ${test_to_run} --scan
   else
     echo "missing vars for function gradleinttest"

--- a/src/gradleinttest.sh
+++ b/src/gradleinttest.sh
@@ -48,8 +48,8 @@ gradleinttest () {
     psql -U postgres -f ./db/create-data-repo-db
     # required for tests
     ./gradlew assemble
-    ./gradlew check --scan
-    ./gradlew ${test_to_run} --scan
+    ./gradlew -w check --scan
+    ./gradlew -w ${test_to_run} --scan
   else
     echo "missing vars for function gradleinttest"
     exit 1


### PR DESCRIPTION
Only display errors and warnings (required to show build scan).