### PR TITLE
Fix: Retrieve latest tag from all branches for deploy-tag-update

### DIFF
--- a/actions/deploy-tag-update/entrypoint.sh
+++ b/actions/deploy-tag-update/entrypoint.sh
@@ -9,7 +9,7 @@ case "${PWD}" in
 esac
 
 # get latest semantic version
-REPO_TAG=$(git describe --tags --abbrev=0)
+REPO_TAG=$(git describe --tags "$(git rev-list --tags --max-count=1)")
 
 cd datarepo-helm-definitions
 


### PR DESCRIPTION
Get latest tag from all branches, not just current branch. This is needed because if the action is running from a slightly older branch, it may apply the older tag instead.