### PR TITLE
DR-1732: add git pull

### DIFF
--- a/actions/main/src/deploytagupdate.sh
+++ b/actions/main/src/deploytagupdate.sh
@@ -26,6 +26,9 @@ deploytagupdate () {
       cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-helm-definitions
       git config --global user.email "robot@jade.team"
       git config --global user.name "imagetagbot"
+      git config pull.rebase false
+      # commit changes to helm definitions
+      git pull origin master
       if [[ "${i}" == "dev" ]]; then
         git add dev/\*.yaml
       else


### PR DESCRIPTION
Should prevent this failure from happening again: https://github.com/DataBiosphere/jade-data-repo-ui/runs/2237946089?check_suite_focus=true

Matches what we have here: https://github.com/broadinstitute/datarepo-actions/blob/master/actions/deploy-tag-update/entrypoint.sh#L29