### PR TITLE
DR-2018 Remove check from connected tests

### DIFF
--- a/actions/main/src/gradleinttest.sh
+++ b/actions/main/src/gradleinttest.sh
@@ -48,6 +48,9 @@ gradleinttest () {
     psql -U postgres -f ./db/create-data-repo-db
     # required for tests
     ./gradlew assemble
+    if [[ "${test_to_run}" == "testIntegration" ]]; then
+      ./gradlew -w check --scan
+    fi
     echo "Running ${test_to_run}"
     ./gradlew -w ${test_to_run} --scan
   else

--- a/actions/main/src/gradleinttest.sh
+++ b/actions/main/src/gradleinttest.sh
@@ -48,7 +48,6 @@ gradleinttest () {
     psql -U postgres -f ./db/create-data-repo-db
     # required for tests
     ./gradlew assemble
-    ./gradlew -w check --scan
     echo "Running ${test_to_run}"
     ./gradlew -w ${test_to_run} --scan
   else


### PR DESCRIPTION
We do this as a part of both connected and integration tests, so its redundant. We'll keep it on the integration tests so that they fail fast and don't allocate resources if we already know something is wrong.