### PR TITLE
DR-2757 Don't run auto-run unit test/spotless as part of integration tests

### DIFF
--- a/actions/main/src/gradleinttest.sh
+++ b/actions/main/src/gradleinttest.sh
@@ -48,9 +48,6 @@ gradleinttest () {
     psql -U postgres -f ./db/create-data-repo-db
     # required for tests
     ./gradlew assemble
-    if [[ "${test_to_run}" == "testIntegration" ]]; then
-      ./gradlew -w check --scan
-    fi
     echo "Running ${test_to_run}"
     ./gradlew -w ${test_to_run} --scan
   else


### PR DESCRIPTION
This means the unit tests and linters (e.g. `gradle check`) should be run explicitly from jade-data-repo