### PR TITLE
DR-2791 Allow filtering down what tests to run

### DIFF
--- a/actions/main/action.yml
+++ b/actions/main/action.yml
@@ -55,6 +55,8 @@ inputs:
     default: "api"
   test_to_run:
     description: "which test you would like to run on the pods ie:testConnected or testIntegration"
+  test_filter:
+    description: "if you'd like to filter down what actual tests to run ie:*TestClass or bio.terra.common.MyTestClass.  Will add to the gradle command as a --tests filter"
   helm_charts_to_test:
     description: "list of helm charts you would like to test"
     default: "create-secret-manager-secret,gcloud-sqlproxy,datarepo-api,datarepo-ui,oidc-proxy"

--- a/actions/main/src/gradleinttest.sh
+++ b/actions/main/src/gradleinttest.sh
@@ -34,6 +34,13 @@ gradleinttest () {
     echo "Running ${test_to_run} test with data project env var unset: ${google_data_project}"
   fi
 
+  if [[ "${test_filter}" == "" ]]; then
+    echo "Running all tests"
+    test_filter_cmd=""
+  else
+    echo "Running subset of tests: ${test_filter}"
+    test_filter_cmd="--tests ${test_filter}"
+  fi
   if [[ -n "${google_project}" ]] && [ -f ${GOOGLE_APPLICATION_CREDENTIALS} ] && [ -f ${GOOGLE_SA_CERT} ] && [[ "${test_to_run}" != "" ]]; then
     export PGHOST=$(ip route show default | awk '/default/ {print $3}')
     export DB_DATAREPO_URI="jdbc:postgresql://${PGHOST}:5432/datarepo"
@@ -49,7 +56,7 @@ gradleinttest () {
     # required for tests
     ./gradlew assemble
     echo "Running ${test_to_run}"
-    ./gradlew -w ${test_to_run} --scan
+    ./gradlew -w ${test_to_run} ${test_filter_cmd} --scan
   else
     echo "missing vars for function gradleinttest"
     exit 1

--- a/actions/main/src/main.sh
+++ b/actions/main/src/main.sh
@@ -68,6 +68,10 @@ parseInputs () {
   if [[ -n "${INPUT_TEST_TO_RUN}" ]]; then
     export test_to_run=${INPUT_TEST_TO_RUN}
   fi
+  test_filter=""
+  if [[ -n "${INPUT_TEST_FILTER}" ]]; then
+    export test_filter=${INPUT_TEST_FILTER}
+  fi
   release_name=""
   if [[ -n "${INPUT_RELEASE_NAME}" ]]; then
     export release_name=${INPUT_RELEASE_NAME}


### PR DESCRIPTION
This can be really helpful when debugging integration tests.  This allows the caller of the action to pass in something like:
```test_filter: "*YourTestClass"```
and that will filter down to only tests that class.  Can speed iteration up pretty significantly