### PR TITLE
DR-2902: add safe directory for non-primary repos (e.g. datarepo-helm-definitions called from jade-data-repo)

### DIFF
--- a/actions/bumper/entrypoint.sh
+++ b/actions/bumper/entrypoint.sh
@@ -16,7 +16,7 @@ PREVIFS=${IFS}
 IFS=','
 
 # check whether we are on a prerelease branch
-git config --global --add safe.directory /github/workspace
+git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 PRE_RELEASE=true
 for BRANCH in ${RELEASE_BRANCH_LIST} ; do

--- a/actions/deploy-tag-update/entrypoint.sh
+++ b/actions/deploy-tag-update/entrypoint.sh
@@ -24,7 +24,7 @@ if [ "${REPO_TAG}" != "${HELM_TAG}" ]; then
     # configure git settings
     git config --global user.email "broadbot@broadinstitute.org"
     git config --global user.name "broadbot"
-    git config --global --add safe.directory /github/workspace
+    git config --global --add safe.directory /github/workspace/datarepo-helm-definitions
     git config pull.rebase false
     # commit changes to helm definitions
     git pull origin master

--- a/actions/deploy-tag-update/entrypoint.sh
+++ b/actions/deploy-tag-update/entrypoint.sh
@@ -24,7 +24,7 @@ if [ "${REPO_TAG}" != "${HELM_TAG}" ]; then
     # configure git settings
     git config --global user.email "broadbot@broadinstitute.org"
     git config --global user.name "broadbot"
-    git config --global --add safe.directory /github/workspace/datarepo-helm-definitions
+    git config --global --add safe.directory "${GITHUB_WORKSPACE}"/datarepo-helm-definitions
     git config pull.rebase false
     # commit changes to helm definitions
     git pull origin master

--- a/actions/helm-deploy/entrypoint.sh
+++ b/actions/helm-deploy/entrypoint.sh
@@ -43,7 +43,7 @@ if [ "${HELM_IMAGETAG_UPDATE}" = "api" ]; then
     helm delete --namespace "${NAMESPACEINUSE}" "${RELEASE_NAME}-datarepo-ui"
 fi
 
-git config --global --add safe.directory /github/workspace
+git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 GCR_TAG=$(git rev-parse --short HEAD)
 
 helm namespace upgrade "${RELEASE_NAME}-create-secret-manager-secret" datarepo-helm/create-secret-manager-secret --version="${HELM_CREATE_SECRET_MANAGER_SECRET_VERSION}" \

--- a/actions/main/src/deploytagupdate.sh
+++ b/actions/main/src/deploytagupdate.sh
@@ -23,31 +23,20 @@ deploytagupdate () {
       printf "Find and replace image with current develop commit\n"
       find . -name ${i}Deployment.yaml -type f -exec sh -c 'yq w -i $1 'datarepo-${helm_imagetag_update}.image.tag' $2-develop' sh {} ${GCR_TAG} ';'
       printf "Git add, commit and push\n"
-      echo `${GITHUB_WORKSPACE}/${workingDir}/datarepo-helm-definitions`
-      ls -a
       cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-helm-definitions
       git config --global user.email "robot@jade.team"
-      echo "Configured user email"
       git config --global user.name "imagetagbot"
-      echo "Configured user name"
       git config --global --add safe.directory /github/workspace
-      echo "Check if in git directory"
-      git rev-parse --is-inside-work-tree
-      echo "set safe directory"
       git config pull.rebase false
-      echo "rebase is false"
       # commit changes to helm definitions
       git pull origin master
-      echo "pull origin master"
       if [[ "${i}" == "dev" ]]; then
         git add dev/\*.yaml
       else
         git add integration/\*.yaml
       fi
       git commit -m "Updated images to latest jade-data-repo commit '${GCR_TAG}'"
-      echo "committed"
       git push origin master
-      echo "pushed"
     done
   else
     echo "helm_env_prefix not defined for function deploytagupdate"

--- a/actions/main/src/deploytagupdate.sh
+++ b/actions/main/src/deploytagupdate.sh
@@ -26,7 +26,7 @@ deploytagupdate () {
       cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-helm-definitions
       git config --global user.email "robot@jade.team"
       git config --global user.name "imagetagbot"
-      git config --global --add safe.directory /github/workspace
+      git config --global --add safe.directory /github/workspace/datarepo-helm-definitions
       git config pull.rebase false
       # commit changes to helm definitions
       git pull origin master

--- a/actions/main/src/deploytagupdate.sh
+++ b/actions/main/src/deploytagupdate.sh
@@ -23,20 +23,31 @@ deploytagupdate () {
       printf "Find and replace image with current develop commit\n"
       find . -name ${i}Deployment.yaml -type f -exec sh -c 'yq w -i $1 'datarepo-${helm_imagetag_update}.image.tag' $2-develop' sh {} ${GCR_TAG} ';'
       printf "Git add, commit and push\n"
+      echo `${GITHUB_WORKSPACE}/${workingDir}/datarepo-helm-definitions`
+      ls -a
       cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-helm-definitions
       git config --global user.email "robot@jade.team"
+      echo "Configured user email"
       git config --global user.name "imagetagbot"
+      echo "Configured user name"
       git config --global --add safe.directory /github/workspace
+      echo "Check if in git directory"
+      git rev-parse --is-inside-work-tree
+      echo "set safe directory"
       git config pull.rebase false
+      echo "rebase is false"
       # commit changes to helm definitions
       git pull origin master
+      echo "pull origin master"
       if [[ "${i}" == "dev" ]]; then
         git add dev/\*.yaml
       else
         git add integration/\*.yaml
       fi
       git commit -m "Updated images to latest jade-data-repo commit '${GCR_TAG}'"
+      echo "committed"
       git push origin master
+      echo "pushed"
     done
   else
     echo "helm_env_prefix not defined for function deploytagupdate"

--- a/actions/main/src/deploytagupdate.sh
+++ b/actions/main/src/deploytagupdate.sh
@@ -26,6 +26,7 @@ deploytagupdate () {
       cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-helm-definitions
       git config --global user.email "robot@jade.team"
       git config --global user.name "imagetagbot"
+      git config --global --add safe.directory /github/workspace
       git config pull.rebase false
       # commit changes to helm definitions
       git pull origin master

--- a/actions/main/src/deploytagupdate.sh
+++ b/actions/main/src/deploytagupdate.sh
@@ -26,7 +26,7 @@ deploytagupdate () {
       cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-helm-definitions
       git config --global user.email "robot@jade.team"
       git config --global user.name "imagetagbot"
-      git config --global --add safe.directory /github/workspace/datarepo-helm-definitions
+      git config --global --add safe.directory "${GITHUB_WORKSPACE}"/datarepo-helm-definitions
       git config pull.rebase false
       # commit changes to helm definitions
       git pull origin master

--- a/actions/main/src/main.sh
+++ b/actions/main/src/main.sh
@@ -152,7 +152,7 @@ helmprerun () {
 }
 
 gitConfigure () {
-  git config --global --add safe.directory /github/workspace
+  git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 }
 
 main () {

--- a/actions/merger/entrypoint.sh
+++ b/actions/merger/entrypoint.sh
@@ -13,6 +13,7 @@ SWITCH_DIRECTORIES=${SWITCH_DIRECTORIES:-false}
 
 if ${SWITCH_DIRECTORIES} ; then
   cd "${GITHUB_WORKSPACE}"/"${GITHUB_REPO}"
+  git config --global --add safe.directory /github/workspace/"${GITHUB_REPO}"
 fi
 
 git config --global user.email "${GITHUB_USER_EMAIL}"

--- a/actions/merger/entrypoint.sh
+++ b/actions/merger/entrypoint.sh
@@ -13,12 +13,12 @@ SWITCH_DIRECTORIES=${SWITCH_DIRECTORIES:-false}
 
 if ${SWITCH_DIRECTORIES} ; then
   cd "${GITHUB_WORKSPACE}"/"${GITHUB_REPO}"
-  git config --global --add safe.directory /github/workspace/"${GITHUB_REPO}"
+  git config --global --add safe.directory "${GITHUB_WORKSPACE}"/"${GITHUB_REPO}"
 fi
 
 git config --global user.email "${GITHUB_USER_EMAIL}"
 git config --global user.name "${GITHUB_USER_NAME}"
-git config --global --add safe.directory /github/workspace
+git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 git config pull.rebase false
 git pull origin "${MERGE_BRANCH}"
 git add .


### PR DESCRIPTION
### Background
Original error message encountered during dev image update action in jade-data-repo:
<img width="593" alt="image" src="https://user-images.githubusercontent.com/13254229/216351851-10802671-abe5-4be7-b267-6cb5d4e6ce2a.png">

I added some extra logging and got the same safe directory error message. Turns out we needed to also specify "datarepo-helm-definitions" when setting the safe directory when we've checked out a repo under a different path ([example](https://github.com/DataBiosphere/jade-data-repo/blob/develop/.github/workflows/dev-image-update.yaml#L40))
<img width="822" alt="image" src="https://user-images.githubusercontent.com/13254229/216351575-856eb2c0-580f-47d1-86ae-56df7aeda83a.png">

### The Changes
1. Add safe directory git config for repos when checked out under a specific path and include the repo name ([example](https://github.com/DataBiosphere/jade-data-repo/blob/develop/.github/workflows/dev-image-update.yaml#L40))
2.  I also went ahead and changed it so that we're using an env variable instead of the string literal for '/github/workspace/'

### Testing
Passing action here: https://github.com/DataBiosphere/jade-data-repo/actions/runs/4075453724
Sanity check unit test run: https://github.com/DataBiosphere/jade-data-repo/actions/runs/4075593972/jobs/7022190951

### Corresponding PRs
Jade-data-repo PR will also go up for review in order to bump the datarepo-actions version: https://github.com/DataBiosphere/jade-data-repo/pull/1403