### PR TITLE
DC-902: Switch back to google hosted apt-key

### DIFF
--- a/actions/main/Dockerfile
+++ b/actions/main/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update -qqy && apt-get install -qqy \
     pip3 install -U crcmod && \
     export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
     echo "deb https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    curl -L https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
     apt-get update && apt-get install -y google-cloud-sdk=${CLOUD_SDK_VERSION}-0 google-cloud-sdk-gke-gcloud-auth-plugin=${CLOUD_SDK_VERSION}-0 $INSTALL_COMPONENTS && \
     gcloud config set core/disable_usage_reporting true && \
     gcloud config set component_manager/disable_update_check true && \

--- a/actions/main/Dockerfile
+++ b/actions/main/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update -qqy && apt-get install -qqy \
     pip3 install -U crcmod && \
     export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
     echo "deb https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    curl -L https://dl.k8s.io/apt/doc/apt-key.gpg | apt-key add - && \
+    curl -L https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
     apt-get update && apt-get install -y google-cloud-sdk=${CLOUD_SDK_VERSION}-0 google-cloud-sdk-gke-gcloud-auth-plugin=${CLOUD_SDK_VERSION}-0 $INSTALL_COMPONENTS && \
     gcloud config set core/disable_usage_reporting true && \
     gcloud config set component_manager/disable_update_check true && \


### PR DESCRIPTION
Reverts changes in https://github.com/broadinstitute/datarepo-actions/commit/a43f4e670aaffad301359bc198cc570c4113b6fb now that k8 mirror has been removed.

The original issue:
https://github.com/kubernetes/k8s.io/pull/4837

Article noting that these legacy packages will be removed by the end of Feb 2024: https://kubernetes.io/blog/2023/08/31/legacy-package-repository-deprecation/