### PR TITLE
DC-904: Unpin google-cloud-sdk and google-cloud-sdk-gke-gcloud-auth-plugin versions

### DIFF
--- a/actions/helm-deploy/Dockerfile
+++ b/actions/helm-deploy/Dockerfile
@@ -1,7 +1,7 @@
 FROM google/cloud-sdk:slim
 
 ENV USE_GKE_GCLOUD_AUTH_PLUGIN=true
-RUN apt-get install -y kubectl google-cloud-sdk-gke-gcloud-auth-plugin=462.0.0-0
+RUN apt-get install -y kubectl google-cloud-sdk-gke-gcloud-auth-plugin
 
 ENV HELM_DATA_HOME /usr/local/share/helm
 

--- a/actions/lock-namespace/Dockerfile
+++ b/actions/lock-namespace/Dockerfile
@@ -1,7 +1,7 @@
 FROM google/cloud-sdk:slim
 
 ENV USE_GKE_GCLOUD_AUTH_PLUGIN=true
-RUN apt-get install -y kubectl google-cloud-sdk-gke-gcloud-auth-plugin=462.0.0-0
+RUN apt-get install -y kubectl google-cloud-sdk-gke-gcloud-auth-plugin
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/actions/main/Dockerfile
+++ b/actions/main/Dockerfile
@@ -1,9 +1,7 @@
 FROM docker:17.12.0-ce as static-docker-source
 
 FROM openjdk:17-slim
-ARG CLOUD_SDK_VERSION=462.0.0
-ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION \
-    CLOUDSDK_PYTHON=python3 \
+ENV CLOUDSDK_PYTHON=python3 \
     HELM_VERSION=v3.1.2 \
     YQ_VERSION=3.2.1 \
     VAULT_VERSION=1.3.2 \
@@ -38,7 +36,7 @@ RUN apt-get update -qqy && apt-get install -qqy \
     export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
     echo "deb https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
-    apt-get update && apt-get install -y google-cloud-sdk=${CLOUD_SDK_VERSION}-0 google-cloud-sdk-gke-gcloud-auth-plugin=${CLOUD_SDK_VERSION}-0 $INSTALL_COMPONENTS && \
+    apt-get update && apt-get install -y google-cloud-sdk google-cloud-sdk-gke-gcloud-auth-plugin $INSTALL_COMPONENTS && \
     gcloud config set core/disable_usage_reporting true && \
     gcloud config set component_manager/disable_update_check true && \
     gcloud config set metrics/environment github_docker_image && \

--- a/actions/unlock-namespace/Dockerfile
+++ b/actions/unlock-namespace/Dockerfile
@@ -1,7 +1,7 @@
 FROM google/cloud-sdk:slim
 
 ENV USE_GKE_GCLOUD_AUTH_PLUGIN=true
-RUN apt-get install -y kubectl google-cloud-sdk-gke-gcloud-auth-plugin=462.0.0-0
+RUN apt-get install -y kubectl google-cloud-sdk-gke-gcloud-auth-plugin
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/actions/wait-for-deployment/Dockerfile
+++ b/actions/wait-for-deployment/Dockerfile
@@ -2,7 +2,7 @@ FROM google/cloud-sdk:slim
 
 ENV USE_GKE_GCLOUD_AUTH_PLUGIN=true
 
-RUN apt-get install -y kubectl google-cloud-sdk-gke-gcloud-auth-plugin=462.0.0-0
+RUN apt-get install -y kubectl google-cloud-sdk-gke-gcloud-auth-plugin
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
Reverts changes in https://github.com/broadinstitute/datarepo-actions/pull/81/files
- Unpin version of google-cloud-sdk-gke-gcloud-auth-plugin
- Unpin version of google-cloud-sdk

Follow up version bumps:
https://github.com/DataBiosphere/jade-data-repo/pull/1614
https://github.com/DataBiosphere/jade-data-repo-ui/pull/1629
and datarepo-helm
