### PR TITLE
DC-923: wait-for-deployment action unable to find google-cloud-cli-gke-gcloud-auth-plugin

### DIFF
--- a/actions/helm-deploy/Dockerfile
+++ b/actions/helm-deploy/Dockerfile
@@ -1,7 +1,7 @@
 FROM google/cloud-sdk:slim
 
 ENV USE_GKE_GCLOUD_AUTH_PLUGIN=true
-RUN apt-get install -y kubectl google-cloud-sdk-gke-gcloud-auth-plugin
+RUN apt-get update && apt-get install -y kubectl google-cloud-sdk-gke-gcloud-auth-plugin
 
 ENV HELM_DATA_HOME /usr/local/share/helm
 

--- a/actions/lock-namespace/Dockerfile
+++ b/actions/lock-namespace/Dockerfile
@@ -1,7 +1,7 @@
 FROM google/cloud-sdk:slim
 
 ENV USE_GKE_GCLOUD_AUTH_PLUGIN=true
-RUN apt-get install -y kubectl google-cloud-sdk-gke-gcloud-auth-plugin
+RUN apt-get update && apt-get install -y kubectl google-cloud-sdk-gke-gcloud-auth-plugin
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/actions/unlock-namespace/Dockerfile
+++ b/actions/unlock-namespace/Dockerfile
@@ -1,7 +1,7 @@
 FROM google/cloud-sdk:slim
 
 ENV USE_GKE_GCLOUD_AUTH_PLUGIN=true
-RUN apt-get install -y kubectl google-cloud-sdk-gke-gcloud-auth-plugin
+RUN apt-get update && apt-get install -y kubectl google-cloud-sdk-gke-gcloud-auth-plugin
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/actions/wait-for-deployment/Dockerfile
+++ b/actions/wait-for-deployment/Dockerfile
@@ -2,7 +2,7 @@ FROM google/cloud-sdk:slim
 
 ENV USE_GKE_GCLOUD_AUTH_PLUGIN=true
 
-RUN apt-get install -y kubectl google-cloud-sdk-gke-gcloud-auth-plugin
+RUN apt-get update && apt-get install -y kubectl google-cloud-sdk-gke-gcloud-auth-plugin
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DC-923
______
The wait-for-deployment action is failing in jade-data-repo. It fails to fetch the google-cloud-cli-gke-gcloud-auth-plugin from packages.cloud.google. Adding an "apt-get update" call fixes this issues. 

Couple of things pointed me to this fix:
- the main datarepo-action is working and it makes the apt-get update call
- instructions for using the [plugin](https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke) instruct that we may need to update gcloud components, so that seems related

Testing:
I pointed the jade-data-repo to this branch and a test run passed: https://github.com/DataBiosphere/jade-data-repo/actions/runs/8254624480

Version bump PRs: 
- https://github.com/DataBiosphere/jade-data-repo/pull/1619
- https://github.com/DataBiosphere/jade-data-repo-ui/pull/1630